### PR TITLE
Redirect Users to Use Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+# Bug Report
+
+
+<font color = green>
+
+# Read + Delete This Green Section Before Submitting
+
+### 1. [Quick Guide on Formatting Markdown for Your Issue](https://www.markdownguide.org/cheat-sheet/)
+
+### 2. Before Submitting this Report You Should Have Done the Following:
+- Followed all steps in the "Troubleshooting Tips" section of the README.md
+- Checked Ed Discussion for any solutions
+
+### 3. Please Remember to Include The Following in Your Issue:
+
+- Any relevant Gradle files
+- Any relevant Java files
+- Screenshot of Spotify dashboard redirect URI
+- System OS
+- Android Studio version
+- Nicely formatted markdown
+
+</font>

--- a/README.md
+++ b/README.md
@@ -260,10 +260,12 @@ Copy `PACKAGE_NAME` and the `SHA1` key and put it on Spotify App's Developer Set
 
 #### 5. None of the Previous Solutions Worked
 
-Check on Ed Discussion for any posts with your specific error. If there aren't any, please make a public post on Ed including the following information:
+Check on Ed Discussion for any posts with your specific error. [**If there aren't any, please open an issue on this repo with the following information:**](https://github.com/thuanvoit/spotify-sdk-tutorial/issues)
+- Any relevant Gradle files
+- Any relevant Java files
+- Screenshot of Spotify dashboard redirect URI
 - System OS
 - Android Studio version
-- Screenshots of your issue
 
 </details>
 


### PR DESCRIPTION
Added:

- Instructions telling students to open issues instead of making Ed posts
- Issue templates to help guide students while making their issues